### PR TITLE
Migration to ESLint 1.0/CLIEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ This will execute the linter in
       modifierName: function(modifierConfig, rules, target) => updatedRules
     }
   },
-  // Options to pass to ESLint
-  eslintOptions: "--ext .js --ext .jsx" //default value,
+  // Extensions that ESLint will look for
+  extensions: [".js", ".jsx"], //default value,
   // Default configuration of your rules to be merged with given config
   defaultConfig: {}
 }
@@ -138,7 +138,7 @@ This will execute the linter in
       react: require("./modifiers/react")
     }
   },
-  eslintOptions: "--ext .js --no-color",
+  extensions: [".js"],
   defaultConfig: {
     targets: {
       global: ["lib"]

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,9 +5,9 @@ module.exports = {
   pkgConfigName: "eslint-myrules",
   version: pkg.version,
   configFilename: ".myrulesrc",
+  extensions: [".js", ".jsx"],
   // List all the different types of rules you have, this is useful to
   // override configs in global.eslintrc
-  eslintOptions: "--ext .js --ext .jsx",
   defaultConfig: {
     targets: {
       global: []

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -14,23 +14,20 @@ exports.run = function(lintConfigs, globalTargets) {
       return console.error(err);
     }
     debug("Starting linter");
-    var args = process.argv.slice(0, 2);
-    var options = myrules.eslintOptions || config.eslintOptions;
-    if(lintConfigs.options) {
-      debug("options:", JSON.stringify(lintConfigs.options));
-      options += " " + lintConfigs.options;
-    }
-    args = args
-      .concat(options.split(" "))
-      .concat(globalTargets)
-      .concat(lintConfigs.targets.global || []);
 
+    var targets = globalTargets.concat(lintConfigs.targets.global || []);
     Object.keys(lintConfigs.targets).forEach(function(target) {
       if(target !== "global") {
-        args = args.concat(lintConfigs.targets[target]);
+        targets = targets.concat(lintConfigs.targets[target]);
       }
     });
 
-    eslint.cli.execute(args);
+    var cli = new eslint.CLIEngine({
+      extensions: myrules.extensions || config.extensions
+    });
+    var report = cli.executeOnFiles(targets);
+    var formatter = cli.getFormatter();
+
+    console.log(formatter(report.results));
   });
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "lint": "node bin/eslint.js lint --debug"
+    "lint": "eslint ."
   },
   "author": "Michael Ferris",
   "dependencies": {
@@ -20,6 +20,6 @@
     "lodash.merge": "^3.1.0"
   },
   "peerDependencies": {
-    "eslint": ">=0.16.0"
+    "eslint": ">=1.0.0"
   }
 }


### PR DESCRIPTION
This is a work in progress, `CLIEngine` has been around for a couple of versions, but since ESLint 1.0 the former `cli.execute` has been removed.

I replaced the "CLI options" (`eslintOptions`) field for an `extensions` one to satisfy my current needs for my use of this tool, but you might want to consider exposing other ones (or I can do it if you greenlight it), they're listed in: http://eslint.org/docs/developer-guide/nodejs-api.html#cliengine

Also, I think the command in the `lint` script in `package.json` was not working, but I'm uncertain as I haven't done extended regression testing.
